### PR TITLE
Add manual step before deploying to b-cld

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -103,6 +103,8 @@ jobs:
         trigger: true
         resource: certs-b.s3
       - get: ops.git
+        passed:
+        - ship-it
         trigger: true
       - get: this.git
     - task: create-release
@@ -154,6 +156,8 @@ jobs:
         trigger: true
         resource: certs-d.s3
       - get: ops.git
+        passed:
+        - create-g-cld
         trigger: true
       - get: this.git
     - task: create-release
@@ -256,6 +260,8 @@ jobs:
         trigger: true
         resource: certs-y.s3
       - get: ops.git
+        passed:
+        - create-d-cld
         trigger: true
       - get: this.git
     - task: create-release
@@ -299,3 +305,8 @@ jobs:
         text: |
           :white_check_mark: $BUILD_PIPELINE_NAME $BUILD_JOB_NAME SUCCESS
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+- name: ship-it
+  plan:
+  - get: ops.git
+    passed:
+    - create-y-cld

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -156,8 +156,6 @@ jobs:
         trigger: true
         resource: certs-d.s3
       - get: ops.git
-        passed:
-        - create-g-cld
         trigger: true
       - get: this.git
     - task: create-release
@@ -260,8 +258,6 @@ jobs:
         trigger: true
         resource: certs-y.s3
       - get: ops.git
-        passed:
-        - create-d-cld
         trigger: true
       - get: this.git
     - task: create-release


### PR DESCRIPTION
The current pipeline has the issue where if the config in ops.git is modified, it is automatically applied in parallel to every environment. This is a bit scary. It is desirable to at least have a human approve the change before it goes to b.

This PR adds this flow:

![image](https://user-images.githubusercontent.com/2324569/33250634-cb458054-d385-11e7-822a-3df55f98ca0d.png)

I have kept the parallel deploys to g, d, and y, as it makes the diagram a little easier to understand I think.

Still need to test it works exactly, but this is the basic idea. I may need to add a noop task within ship-it to get the input to flow through the output properly.

