### PR TITLE
Allow the certs/ directory to already exist

### DIFF
--- a/ci/scripts/create-release.sh
+++ b/ci/scripts/create-release.sh
@@ -11,7 +11,11 @@ mkdir release-candidate
 
 cp -rf ops.git/frontend/config-bucket/* release-candidate
 
-mkdir release-candidate/certs
+# This directory is managed by the cert manager, but it might already exist in
+# the repo for testing purposes
+mkdir -p release-candidate/certs
+rm -rf release-candidate/certs/*
+
 tar xvfz certs.s3/current-certificates.tgz -C release-candidate/certs
 
 # Now the release-candidate dir contains an extracted haproxy config we can


### PR DESCRIPTION
With this change, the pipeline won't fail if the certs/ directory
already exists, or it contains extra files (they'll be deleted).

This allows us to add a dummy cert to the repo for easy local testing.